### PR TITLE
add web_server show_target_stats switch

### DIFF
--- a/leapmmw_sensor.h
+++ b/leapmmw_sensor.h
@@ -105,8 +105,11 @@ class leapmmw : public Component, public UARTDevice {
               }
           }
           id(num_targets).publish_state(parse_number<float>(v[0]).value());
-          publishTarget(v[1], parse_number<float>(v[2]).value(), parse_number<float>(v[4]).value());
-          for(int i = parse_number<int>(v[0]).value() +1 ; i < 9; i++) publishTarget(to_string(i), 0, 0);
+          if (id(show_target_stats).state == 1) {
+            publishTarget(v[1], parse_number<float>(v[2]).value(), parse_number<float>(v[4]).value());
+            // zero null targets
+            for(int i = parse_number<int>(v[0]).value() +1 ; i < 9; i++) publishTarget(to_string(i), 0, 0);
+          }
         }
         if (line.substr(0, 6) == "$JYRPO" && id(mmwave_sensor).state == 0) {
           publishSwitch("mmwave_sensor", 1);

--- a/packages/leapmmw_sensor.yml
+++ b/packages/leapmmw_sensor.yml
@@ -10,6 +10,10 @@ esphome:
   includes:
     - ${header_file}
 
+logger:
+  logs:
+    sensor: INFO # reduced logging to minimize web_server target overload..
+
 uart:
   id: uart_bus
   tx_pin: ${uart_tx_pin}
@@ -202,8 +206,8 @@ button:
           data: "resetSystem 0"
 
   - platform: template
-    name: factory_reset_MCU_${device_name}
-    id: factory_reset_MCU
+    name: factory_reset_mmwMCU_${device_name}
+    id: factory_reset_mmwMCU
     entity_category: diagnostic
     on_press:
       - switch.turn_off: mmwave_sensor

--- a/packages/leapmmw_sensor.yml
+++ b/packages/leapmmw_sensor.yml
@@ -24,6 +24,7 @@ binary_sensor:
   - platform: gpio
     name: mmwave_presence_detection
     id: mmwave_presence_detection
+    device_class: motion
     pin:
       number: ${gpio_pin}
       mode: INPUT_PULLDOWN
@@ -82,6 +83,7 @@ sensor:
   - platform: template
     name: num_targets
     id: num_targets # do not change
+    accuracy_decimals: 0
 
   - platform: custom
     lambda: |-

--- a/packages/leapmmw_sensor.yml
+++ b/packages/leapmmw_sensor.yml
@@ -95,6 +95,14 @@ switch:
     name: use_safe_mode
 
   - platform: template
+    name: show_target_stats
+    id: show_target_stats
+    optimistic: true
+    internal: true
+    on_turn_off:
+      - lambda: 'return clearTargets();'
+
+  - platform: template
     name: mmwave_sensor
     id: mmwave_sensor # do not change
     entity_category: config


### PR DESCRIPTION
Added a web_server internal switch to only show target stats when enabled.  No point in publishing all that data unless it is needed.