### PR TITLE
Re-enable custom components

### DIFF
--- a/ci/sample-pipico-debug.yaml
+++ b/ci/sample-pipico-debug.yaml
@@ -14,9 +14,6 @@ packages:
   
 rp2040:
   board: rpipicow
-  framework:
-    platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git
-
 
 # Enable logging
 logger:

--- a/ci/sample-pipico.yaml
+++ b/ci/sample-pipico.yaml
@@ -14,9 +14,6 @@ packages:
   
 rp2040:
   board: rpipicow
-  framework:
-    platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git
-
 
 # Enable logging
 logger:

--- a/packages/leapmmw_sensor.yml
+++ b/packages/leapmmw_sensor.yml
@@ -12,6 +12,12 @@ esphome:
   includes:
     - ${header_file}
 
+external_components:
+  - source:
+      type: git
+      url: https://github.com/robertklep/esphome-custom-component
+    components: [ custom, custom_component ]
+
 logger:
   logs:
     sensor: INFO # reduced logging to minimize web_server target overload..


### PR DESCRIPTION
Attemping to fix the build error by incorporating an external component that re-enables custom components.

Fixes https://github.com/hjmcnew/esphome-hs2xx3a-custom-component/issues/32