### PR TITLE
Fix build errors with 2025.7.0

### DIFF
--- a/leapmmw_sensor.h
+++ b/leapmmw_sensor.h
@@ -1,11 +1,14 @@
 #include "esphome.h"
 #include <string>
+#include <sstream>
 
 void publishTarget(std::string idx, float dist, float snr) {
   auto get_sensors = App.get_sensors();
   for(int i = 0; i < get_sensors.size(); i++) {
     std::string name = get_sensors[i]->get_name();
-    auto target = "target_" + to_string(idx);
+    std::stringstream ptss;
+    ptss << idx;
+    auto target = "target_" + ptss.str();
     if(name.size() > 10 && name.substr(0, 8) == target) {
       if(name.substr(9, 3) == "dis") {
         get_sensors[i]->publish_state(dist);
@@ -16,7 +19,11 @@ void publishTarget(std::string idx, float dist, float snr) {
   }
 };
 static void clearTargets () {
-  for(int i = 1 ; i < 9; i++) publishTarget(to_string(i), 0, 0);
+  for(int i = 1 ; i < 9; i++) {
+    std::stringstream ctss;
+    ctss << i;
+    publishTarget(ctss.str(), 0, 0);
+  }
 }
 
 


### PR DESCRIPTION
This pull request updates the `leapmmw_sensor.h` file to improve the handling of string conversions by replacing `std::to_string` with `std::stringstream`. This change ensures better compatibility and consistency in string manipulation.

### String conversion improvements:

* Replaced `std::to_string` with `std::stringstream` for constructing the `target` string in the `publishTarget` function. (`[leapmmw_sensor.hR3-R11](diffhunk://#diff-f105cdec5f84542760ada962b9ff1facb32ccf648a11b80bdadb8d79bc9c550aR3-R11)`)
* Updated the `clearTargets` function to use `std::stringstream` instead of `std::to_string` for converting integers to strings before calling `publishTarget`. (`[leapmmw_sensor.hL19-R26](diffhunk://#diff-f105cdec5f84542760ada962b9ff1facb32ccf648a11b80bdadb8d79bc9c550aL19-R26)`)